### PR TITLE
Added relay settings to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,12 @@ OKTA_CLIENT_SECRET=
 # So CAS & Okta know where to redirect back to.
 SITE_URL=
 
+# Relay / Mobile App
+RELAY_ENABLED=false
+RELAY_SERVER_URL=https://mcc.example.com
+RELAY_SERVER_TOKEN=
+PWA_URL=https://pwa.example.com
+
 # Docker image versions
 AB_WEB_VERSION=develop
 AB_CONFIG_VERSION=develop

--- a/config/local.js
+++ b/config/local.js
@@ -144,6 +144,21 @@ module.exports = {
    /* end process_manager */
 
    /**
+    * relay
+    */
+   relay: {
+      enable: process.env.RELAY_ENABLED == "true" ? true : false,
+      mcc: {
+         enabled: process.env.RELAY_ENABLED == "true" ? true : false,
+         url: process.env.RELAY_SERVER_URL,
+         accessToken: process.env.RELAY_SERVER_TOKEN,
+         pollFrequency: process.env.RELAY_POLL_FREQUENCY ?? 1000 * 5, // 5s
+         maxPacketSize: process.env.RELAY_MAX_PACKET_SIZE ?? 1024 * 1024,
+      },
+      pwaURL: process.env.PWA_URL,
+   },
+
+   /**
     * tenant_manager
     * manages the different tenants in our system
     */

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,15 +72,16 @@ services:
     image: docker.io/digiserve/ab-api-sails:$AB_API_SAILS_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
-      - CAS_ENABLED=$CAS_ENABLED
-      - CAS_BASE_URL=$CAS_BASE_URL
-      - CAS_UUID_KEY=$CAS_UUID_KEY
-      - SITE_URL=$SITE_URL
-      - OKTA_ENABLED=$OKTA_ENABLED
-      - OKTA_DOMAIN=$OKTA_DOMAIN
-      - OKTA_CLIENT_ID=$OKTA_CLIENT_ID
-      - OKTA_CLIENT_SECRET=$OKTA_CLIENT_SECRET
+      - MYSQL_PASSWORD # from .env
+      - CAS_ENABLED
+      - CAS_BASE_URL
+      - CAS_UUID_KEY
+      - SITE_URL
+      - OKTA_ENABLED
+      - OKTA_DOMAIN
+      - OKTA_CLIENT_ID
+      - OKTA_CLIENT_SECRET
+      - RELAY_SERVER_TOKEN
     volumes:
       - config:/app/config
       - files:/data
@@ -95,7 +96,7 @@ services:
     image: docker.io/digiserve/ab-appbuilder:$AB_APPBUILDER_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:
@@ -129,7 +130,7 @@ services:
     image: docker.io/digiserve/ab-custom-reports:$AB_CUSTOM_REPORTS_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:
@@ -143,7 +144,7 @@ services:
     image: docker.io/digiserve/ab-definition-manager:$AB_DEFINITION_MANAGER_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:
@@ -157,7 +158,7 @@ services:
     image: docker.io/digiserve/ab-file-processor:$AB_FILE_PROCESSOR_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
       - files:/data
@@ -172,7 +173,7 @@ services:
     image: docker.io/digiserve/ab-log-manager:$AB_LOG_MANAGER_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:
@@ -186,7 +187,7 @@ services:
     image: docker.io/digiserve/ab-notification-email:$AB_NOTIFICATION_EMAIL_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:
@@ -200,7 +201,7 @@ services:
     image: docker.io/digiserve/ab-process-manager:$AB_PROCESS_MANAGER_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:
@@ -214,7 +215,13 @@ services:
     image: docker.io/digiserve/ab-relay:$AB_RELAY_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
+      - RELAY_ENABLED
+      - RELAY_SERVER_URL
+      - RELAY_SERVER_TOKEN
+      - RELAY_POLL_FREQUENCY
+      - RELAY_MAX_PACKET_SIZE
+      - PWA_URL
     hostname: relay
     volumes:
       - config:/app/config
@@ -229,7 +236,7 @@ services:
     image: docker.io/digiserve/ab-tenant-manager:$AB_TENANT_MANAGER_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:
@@ -243,7 +250,7 @@ services:
     image: docker.io/digiserve/ab-user-manager:$AB_USER_MANAGER_VERSION
     environment:
       - COTE_DISCOVERY_REDIS_HOST=redis
-      - MYSQL_PASSWORD=$MYSQL_PASSWORD # from .env
+      - MYSQL_PASSWORD # from .env
     volumes:
       - config:/app/config
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       - OKTA_DOMAIN
       - OKTA_CLIENT_ID
       - OKTA_CLIENT_SECRET
+      - RELAY_ENABLED
       - RELAY_SERVER_TOKEN
     volumes:
       - config:/app/config


### PR DESCRIPTION
I'm unsure if there are other AB services that reference the relay settings. Logically, only `ab_service_relay` should, but I know of one exception in `ab_service_api_sails`: the authUser.js policy uses the relay server token to parse requests forwarded by the relay service.